### PR TITLE
relative urls as default also for the symfony2 plugin

### DIFF
--- a/lessc.inc.php
+++ b/lessc.inc.php
@@ -77,7 +77,7 @@ class lessc{
 	}
 
 	protected function getOptions(){
-		$options = array();
+		$options = array('relativeUrls'=>false);
 		switch($this->formatterName){
 			case 'compressed':
 				$options['compress'] = true;


### PR DESCRIPTION
the last commit already uses relativeUrls=false for the bash script.
the default of true fucks up urls for the fonts in the braincrafted bootstrap bundle.
this is an easy fix.
